### PR TITLE
Ensure that everyone uses the less privileged workflow

### DIFF
--- a/docs/development/submitting-changes.rst
+++ b/docs/development/submitting-changes.rst
@@ -27,11 +27,7 @@ Publishing Changes
 
 The first step to submit changes is to publish them so that other contributors can review and give feedback.
 
-The mechanism to publish your changes depends on whether you have write access to the repository. Write access
-is granted by the Steering Council to recurrent, or trusted contributors.
-
-* Contributors with write access should publish a branch on the repository.
-* Contributors without write access should publish as a branch on a fork of the repository.
+Branches should be published on GitHub on a fork of the j5 repository.
 
 Pull Requests
 -------------


### PR DESCRIPTION
This PR partially exists so that I can test the CI

## Checklist

- [x] I have updated the relevant documentation
- [x] I have added the `semver-major`, `semver-minor` or `semver-patch` label as appropriate
- [ ] I would like multiple reviewers to approve my code before merging

## Why do you want to make these changes?

All contributors should use the less-privileged workflow to ensure that our CI behaves appropriately.

## Which parts of the codebase do your changes affect?

None

## How do your changes affect student or volunteer experience?

N/A

## Are your changes related to any existing issues or PRs? How so?

Fixes #571